### PR TITLE
Relax dependency version constraints

### DIFF
--- a/Fuchu.Xunit/paket.template
+++ b/Fuchu.Xunit/paket.template
@@ -1,4 +1,4 @@
 ﻿type project
 id Fuchu.Xunit
 authors Fyodor Soikin
-version 0.1.0
+version 0.2.0

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,12 +2,12 @@ source https://www.nuget.org/api/v2/
 
 nuget FAKE
 
-nuget FSharpx.Extras 1.10.3 framework: >= net45
-nuget FsUnit.xUnit 1.4.1.0 framework: >= net45
-nuget Fuchu 1.0.2.0 framework: >= net45
-nuget xunit 2.1.0 framework: >= net45
-nuget xunit.abstractions 2.0.0 framework: >= net45
-nuget xunit.extensibility.core 2.1.0 framework: >= net45
-nuget xunit.extensibility.execution 2.1.0 framework: >= net45
-nuget xunit.runner.console 2.1.0 framework: >= net45
+nuget FSharpx.Extras ~> 1.10 framework: >= net45
+nuget FsUnit.xUnit ~> 1.4 framework: >= net45
+nuget Fuchu ~> 1.0 framework: >= net45
+nuget xunit ~> 2.1 framework: >= net45
+nuget xunit.abstractions ~> 2.0 framework: >= net45
+nuget xunit.extensibility.core ~> 2.1 framework: >= net45
+nuget xunit.extensibility.execution ~> 2.1 framework: >= net45
+nuget xunit.runner.console ~> 2.1 framework: >= net45
 nuget xunit.runner.visualstudio >= 2.1.0 version_in_path: true


### PR DESCRIPTION
The version constraints were pinned to specific versions in paket.dependencies. These are picked up by the paket.template to specify the nupkg constraints. This meant that I couldn't install the package because the version numbers were too tight. 

I've only relaxed them within major versions so should be okay if the dependencies are all SemVer (looks like it)